### PR TITLE
A11y for words

### DIFF
--- a/src/components/session.js
+++ b/src/components/session.js
@@ -12,7 +12,7 @@ export default props => {
           <div className = "sessionIntro">
           <MDXRenderer>{sessionIntro ? sessionIntro : null}</MDXRenderer>
           </div>
-            <ul>
+            <div className="wordsList">
               {sessionWords.map((definition, i) =>
                 <Word
                 key= {i}
@@ -22,7 +22,7 @@ export default props => {
                 example = {definition.data.example}
                 />
                 )}
-            </ul>
+            </div>
 
         </div>
       )

--- a/src/components/word.js
+++ b/src/components/word.js
@@ -11,12 +11,13 @@ export default props =>  {
     },[]);
     
     return (
-        <li key={key} className="clickable" onClick={() => setVisible(!visible)}>
+        <div key={key} className = "definition">
+        <a  className="clickable" onClick={() => setVisible(!visible)}>
             <span className="word" style={{clipPath:`polygon(`+angles[0]+`% 0%, 100% 2%,`+ angles[1]+`% 100%, 0% 99%)`}}>
                 {capitalize(word)}
             </span> 
+        </a>
             <span className={visible? "metadata loaded" : "metadata"}>
-                
                 <span className="type">
                     {type}  ·
                 </span> 
@@ -32,6 +33,7 @@ export default props =>  {
                 : null}
                 </div>
              </span>
-      </li>
+
+      </div>
     )
 }

--- a/src/components/word.js
+++ b/src/components/word.js
@@ -12,11 +12,9 @@ export default props =>  {
     
     return (
         <div key={key} className = "definition">
-        <a  className="clickable" onClick={() => setVisible(!visible)}>
-            <span className="word" style={{clipPath:`polygon(`+angles[0]+`% 0%, 100% 2%,`+ angles[1]+`% 100%, 0% 99%)`}}>
+        <button type="button" className="word" style={{clipPath:`polygon(`+angles[0]+`% 0%, 100% 2%,`+ angles[1]+`% 100%, 0% 99%)`}} onClick={() => setVisible(!visible)}>
                 {capitalize(word)}
-            </span> 
-        </a>
+        </button>
             <span className={visible? "metadata loaded" : "metadata"}>
                 <span className="type">
                     {type}  ·

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -62,12 +62,6 @@ a {
   color:var(--grey);
 }
 
-.wordsList a {
-  padding-top:20px;
-  padding-left:0px;
-  margin-left:0px;
-}
-
  .metadata {
    display:block;
    height: 0;
@@ -83,13 +77,17 @@ a {
  }
 
 .word {
+  padding:8px 12px; 
   background:var(--red);
+  display:inline-block;
+  border:none;
   color:#fff;
-  font-size: 2em;
+  font-size: 1.9em;
   font-family:Georgia, 'Times New Roman', Times, serif;
-  padding: 0 8px 4px 8px; 
-  /* border-radius:2px; */
   user-select:none;
+  margin-left:0px;
+  cursor:pointer;
+  box-sizing: content-box;
 }
 
 .type {
@@ -134,11 +132,6 @@ a {
 .example {
   font-style: italic;
   background-color:#e3e3e3;
-}
-
-
-.clickable {
-  cursor:pointer;
 }
 
 .article {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -2,6 +2,7 @@
 
 :root {
   --red: #C34C4F;
+  --darkred: #993c3d;
   --grey: grey;
   --white: #ffffff;
 }
@@ -39,7 +40,7 @@ a {
   grid-gap: 40px;
   /* disabling tap highlight on iOS */
   -webkit-tap-highlight-color: rgba(0,0,0,0);
-  margin: 0px;
+  margin: 40px 0px 0px 0px;
 }
 
 .sessionTitle {
@@ -77,17 +78,22 @@ a {
  }
 
 .word {
-  padding:8px 12px; 
+  padding:10px 12px; 
   background:var(--red);
-  display:inline-block;
+  display:inline-flex;
   border:none;
   color:#fff;
-  font-size: 1.9em;
+  font-size: 2em;
   font-family:Georgia, 'Times New Roman', Times, serif;
   user-select:none;
   margin-left:0px;
   cursor:pointer;
   box-sizing: content-box;
+}
+
+.word:hover{
+  background-color:var(--darkred);
+  transition:.5s;
 }
 
 .type {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -66,7 +66,6 @@ li {
   padding-top:20px;
   padding-left:0px;
   margin-left:0px;
-  cursor:default;
 }
 
  .metadata {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -6,14 +6,15 @@
   --white: #ffffff;
 }
 
-
 a {
   color:var(--red);
 }
+
 .header {
   font-weight:500;
   margin-bottom:20px;
 }
+
 .container {
   margin:40px 20px 0px 40px;
 }
@@ -32,10 +33,10 @@ a {
   margin-bottom:60px;
 }
 
-.session ul {
+.wordsList {
   display:grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  grid-gap: 10px;
+  grid-gap: 40px;
   /* disabling tap highlight on iOS */
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   margin: 0px;
@@ -61,8 +62,7 @@ a {
   color:var(--grey);
 }
 
-li {
-  list-style-type: none;
+.wordsList a {
   padding-top:20px;
   padding-left:0px;
   margin-left:0px;
@@ -82,7 +82,7 @@ li {
     max-height: 200px;
  }
 
-li .word {
+.word {
   background:var(--red);
   color:#fff;
   font-size: 2em;
@@ -92,13 +92,13 @@ li .word {
   user-select:none;
 }
 
-li .type {
+.type {
   font-size:0.7em;
   font-style: oblique;
   font-family:Georgia, 'Times New Roman', Times, serif;
 }
 
-li .translation {
+.translation {
   margin-left:2px;
 }
 


### PR DESCRIPTION
Made each "word" on the site a `button` instead of a `li`. This fixes two eslint warnings that flagged one shouldn't make non-interactive components such as `li` interactive - it's more semantic to use a `button`.